### PR TITLE
Add `id`s to definitions for linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,18 @@ bower install markdown-it-deflist --save
 
 ```js
 var md = require('markdown-it')()
-            .use(require('markdown-it-deflist'));
+            .use(require('markdown-it-deflist'), options);
 
 md.render(/*...*/);
 ```
+
+The options object can contain:
+
+Name            | Description                                     | Default
+----------------|-------------------------------------------------|--------
+`createAnchors` | Whether to add `id`s to definitions for linking | `true`
+`slugPrefix`    | Prefix to use when creating ids                 | `markdown-def-`
+`slugify`       | Custom function to create id                    | See [`index.js`](index.js)
 
 _Differences in browser._ If you load script directly into the page, without
 package system, module will add itself globally as `window.markdownitDeflist`.

--- a/test/fixtures/deflist.txt
+++ b/test/fixtures/deflist.txt
@@ -15,11 +15,11 @@ Term 2 with *inline markup*
   Third paragraph of definition 2.
 .
 <dl>
-<dt>Term 1</dt>
+<dt id="markdown-def-term-1">Term 1</dt>
 <dd>
 <p>Definition 1</p>
 </dd>
-<dt>Term 2 with <em>inline markup</em></dt>
+<dt id="markdown-def-term-2-with--inline-markup-">Term 2 with <em>inline markup</em></dt>
 <dd>
 <p>Definition 2</p>
 <pre><code>{ some code, part of Definition 2 }
@@ -40,7 +40,7 @@ with lazy continuation.
     Second paragraph of the definition.
 .
 <dl>
-<dt>Term 1</dt>
+<dt id="markdown-def-term-1">Term 1</dt>
 <dd>
 <p>Definition
 with lazy continuation.</p>
@@ -60,9 +60,9 @@ Term 2
   ~ Definition 2b
 .
 <dl>
-<dt>Term 1</dt>
+<dt id="markdown-def-term-1">Term 1</dt>
 <dd>Definition 1</dd>
-<dt>Term 2</dt>
+<dt id="markdown-def-term-2">Term 2</dt>
 <dd>Definition 2a</dd>
 <dd>Definition 2b</dd>
 </dl>
@@ -78,9 +78,9 @@ Term 2
   :     code block
 .
 <dl>
-<dt>Term 1</dt>
+<dt id="markdown-def-term-1">Term 1</dt>
 <dd>paragraph</dd>
-<dt>Term 2</dt>
+<dt id="markdown-def-term-2">Term 2</dt>
 <dd>
 <pre><code>code block
 </code></pre>
@@ -116,14 +116,14 @@ Term 2
 : bar
 .
 <dl>
-<dt>Term 1</dt>
+<dt id="markdown-def-term-1">Term 1</dt>
 <dd>
 <p>foo</p>
 </dd>
 <dd>
 <p>bar</p>
 </dd>
-<dt>Term 2</dt>
+<dt id="markdown-def-term-2">Term 2</dt>
 <dd>
 <p>foo</p>
 </dd>
@@ -144,7 +144,7 @@ Term 2
 : foo
 .
 <dl>
-<dt>Term 1</dt>
+<dt id="markdown-def-term-1">Term 1</dt>
 <dd>
 <p>foo</p>
 <p>bar
@@ -177,13 +177,13 @@ test
   : foo
 .
 <dl>
-<dt>test</dt>
+<dt id="markdown-def-test">test</dt>
 <dd>
 <dl>
-<dt>foo</dt>
+<dt id="markdown-def-foo">foo</dt>
 <dd>
 <dl>
-<dt>bar</dt>
+<dt id="markdown-def-bar">bar</dt>
 <dd>baz</dd>
 </dl>
 </dd>
@@ -201,7 +201,7 @@ Term 1
   :		code block
 .
 <dl>
-<dt>Term 1</dt>
+<dt id="markdown-def-term-1">Term 1</dt>
 <dd>
 <pre><code>code block
 </code></pre>
@@ -217,7 +217,7 @@ foo
 : baz
 .
 <dl>
-<dt>foo</dt>
+<dt id="markdown-def-foo">foo</dt>
 <dd>
 <blockquote>
 <p>bar</p>


### PR DESCRIPTION
We use the deflist to create a glossary and need to link to specific definitions.

I ran unittest and they fail on the branch upstream master branch.  I did not attempt to correct that, but I did fix the tests relative to these changes so they don't fail any more than they did.