### PR TITLE
Correct lazy paragraph continuations

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -42,7 +42,8 @@ export default function deflist_plugin (md) {
     if (silent) {
       // quirk: validation mode validates a dd block only, not a whole deflist
       if (state.ddIndent < 0) { return false }
-      return skipMarker(state, startLine) >= 0
+      const markerPos = skipMarker(state, startLine)
+      return markerPos >= 0 && state.sCount[startLine] < state.blkIndent
     }
 
     let nextLine = startLine + 1

--- a/test/fixtures/deflist.txt
+++ b/test/fixtures/deflist.txt
@@ -245,3 +245,60 @@ test
 .
 <p>test</p>
 .
+
+
+A lazy continuation may start with a `:`, if it has enough indent.
+.
+apple
+   : > computer company
+     : red fruit
+
+orange
+   : > telecom company
+   : orange fruit
+
+chili's
+   : > restaurant company
+ : spicy fruit
+.
+<dl>
+<dt>apple</dt>
+<dd>
+<blockquote>
+<p>computer company
+: red fruit</p>
+</blockquote>
+</dd>
+<dt>orange</dt>
+<dd>
+<blockquote>
+<p>telecom company</p>
+</blockquote>
+</dd>
+<dd>orange fruit</dd>
+<dt>chili's</dt>
+<dd>
+<blockquote>
+<p>restaurant company</p>
+</blockquote>
+</dd>
+<dd>spicy fruit</dd>
+</dl>
+.
+
+It may not, however, lazily act as a definition in a list.
+.
+> cherry
+> : keyboard company
+> pomegranate
+: tart fruit
+.
+<blockquote>
+<dl>
+<dt>cherry</dt>
+<dd>keyboard company
+pomegranate
+: tart fruit</dd>
+</dl>
+</blockquote>
+.


### PR DESCRIPTION
This change makes markdown-it act the same way commonmark-hs's definition list extension acts.

[pandoc.org/try preview](https://pandoc.org/try/?params=%7B%22text%22%3A%22%23+A+lazy+continuation+may+start+with+a+%60%3A%60%2C+if+it+has+enough+indent.%5Cn%5Cnapple%5Cn+++%3A+%3E+computer+company%5Cn+++++%3A+red+fruit%5Cn%5Cnorange%5Cn+++%3A+%3E+telecom+company%5Cn+++%3A+orange+fruit%5Cn%5Cnchili%27s%5Cn+++%3A+%3E+restaurant+company%5Cn+%3A+spicy+fruit%5Cn%5Cn%23+It+may+not%2C+however%2C+lazily+act+as+a+definition+in+a+list.%5Cn%5Cn%3E+cherry%5Cn%3E+%3A+keyboard+company%5Cn%3E+pomegranate%5Cn%3A+tart+fruit%5Cn%22%2C%22to%22%3A%22html5%22%2C%22from%22%3A%22commonmark_x%22%2C%22standalone%22%3Afalse%2C%22embed-resources%22%3Afalse%2C%22table-of-contents%22%3Afalse%2C%22number-sections%22%3Afalse%2C%22citeproc%22%3Afalse%2C%22html-math-method%22%3A%22plain%22%2C%22wrap%22%3A%22auto%22%2C%22highlight-style%22%3Anull%2C%22files%22%3A%7B%7D%2C%22template%22%3Anull%7D)